### PR TITLE
Increase PhaseTracker UI offset

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -2841,9 +2841,9 @@ function createPhaseTrackerUI()
       color                                = "black",
       visibility                           = visibilityString,
       active                               = visibilityString ~= "",
-      height                               = "95",
-      width                                = "95",
-      offsetXY                             = "-2 473",
+      height                               = 95,
+      width                                = 95,
+      offsetXY                             = "-2 562",
       allowDragging                        = true,
       returnToOriginalPositionWhenReleased = false,
       rectAlignment                        = "LowerRight",
@@ -2858,7 +2858,7 @@ function createPhaseTrackerUI()
           id      = "phaseTrackerUIButton",
           onClick = "onClick_phaseTrackerChangeState",
           height  = 95,
-          width   = 95,
+          width   = 95
         },
         children = {
           tag = "Image",


### PR DESCRIPTION
Ensures the default position of the PhaseTracker UI is not on top of the action tracker for 4-player sessions.