### PR TITLE
Fix a bug with RBW drawing

### DIFF
--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -1069,33 +1069,29 @@ function buildAvailableWeaknesses(restrictions)
   -- basicWeaknessList is sorted, so later duplicates with the same name overwrite earlier versions
   local uniqueNameMap = {} -- Temporary map: [Name] = { ID, count }
   for _, weaknessId in ipairs(basicWeaknessList) do
-    if inPlay[weaknessId] and inPlay[weaknessId] > 0 then
-      inPlay[weaknessId] = inPlay[weaknessId] - 1
-    else
+    local card              = cardIdIndex[weaknessId] or {}
+    local md                = card.metadata or {}
+    local name              = card.data.Nickname
+    local totalCount        = md.basicWeaknessCount or 1
+    local inPlayCount       = inPlay[weaknessId] or 0
+    local availableCount    = math.max(0, totalCount - inPlayCount)
+
+    if availableCount > 0 then
       local eligible = true
-      local card     = cardIdIndex[weaknessId] or {}
-      local md       = card.metadata or {}
-      local name     = card.data.Nickname
 
       -- filter for correct chapter
-      if restrictions.chapter then
-        if not restrictions.chapter[md.chapter] then
-          eligible = false
-        end
+      if restrictions.chapter and not restrictions.chapter[md.chapter] then
+        eligible = false
       end
 
       -- disable 'Campaign only' weaknesses in standalone mode
-      if restrictions.standalone then
-        if md.modeRestriction == "Campaign" then
-          eligible = false
-        end
+      if restrictions.standalone and md.modeRestriction == "Campaign" then
+        eligible = false
       end
 
       -- disable class restricted weaknesses
-      if restrictions.class then
-        if md.classRestriction and md.classRestriction ~= restrictions.class then
-          eligible = false
-        end
+      if restrictions.class and md.classRestriction and md.classRestriction ~= restrictions.class then
+        eligible = false
       end
 
       -- disable non-matching traits
@@ -1131,7 +1127,7 @@ function buildAvailableWeaknesses(restrictions)
 
       -- add weakness to list if eligible
       if eligible and name then
-        uniqueNameMap[name] = { id = weaknessId, count = md.basicWeaknessCount }
+        uniqueNameMap[name] = { id = weaknessId, count = availableCount }
       end
     end
   end


### PR DESCRIPTION
Previously, the random basic weakness count was considered until such a card was drawn, then that card was marked ineligible, despite having more eligible copies.