### PR TITLE
Export of Chaos Token Stats to Google Sheets

### DIFF
--- a/modsettings/TabStates.json
+++ b/modsettings/TabStates.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "body": "Welcome to Arkham Horror LCG - Super Complete Edition!\n\nMake sure to take the tour that can be started with the token in the middle of the main playarea. Some basic notes:\n\nDECKBUILDING\n- All currently existing investigators and player cards are accessible via the player card panel in the upper left corner of the table.\n\n- On the leftside underneath the Investigators, you will find the ArkhamDB Deckimporter. Insert your deck ID and it will build the deck automatically for you.\n\nSCENARIOS \u0026 SETUP\n- Arkham Horror LCG comes with a core campaign (Night of the Zealot) and several expansions. Within each box you will find all the cards required for each scenario setup, as well as a the official campaign guide PDF.\n\n2. Each scenario is setup differently, and while some of the work has been prepared beforehand (such as building encounter decks), you will have to refer to the Campaign Guide for specific instructions on how to set up each scenario.\n\nINVESTIGATOR PLAYMAT AND GAMEPLAY\n- Playermats are scripted to automate most of the gameplay for you.",
+    "body": "Welcome to Arkham Horror LCG - Super Complete Edition!\n\nMake sure to take the tour that can be started with the token in the middle of the main playarea. Some basic notes:\n\nDECKBUILDING\n- All currently existing investigators and player cards are accessible via the player card panel in the upper left corner of the table.\n\n- On the leftside underneath the Investigators, you will find the ArkhamDB Deckimporter. Insert your deck ID and it will build the deck automatically for you.\n\n- It is recommended to use https://arkham.build/ instead of ArkhamDB.\n\nSCENARIOS \u0026 SETUP\n- Arkham Horror LCG comes with a core campaign (Night of the Zealot) and several expansions. Within each box you will find all the cards required for each scenario setup, as well as a the official campaign guide PDF.\n\n- Each scenario is setup differently, and while some of the work has been prepared beforehand (such as building encounter decks), you will have to refer to the Campaign Guide for specific instructions on how to set up each scenario.\n\nINVESTIGATOR PLAYMAT AND GAMEPLAY\n- Playermats are scripted to automate most of the gameplay for you.",
     "color": "Grey",
     "id": 0,
     "title": "Basic Intro",
@@ -14,7 +14,18 @@
     "body": "You can instruct the mod to import custom cards with your ArkhamDB deck by putting 'instructions' in the deck description.\nThere's a tool to generate them left of the deck importer. Simply place your cards on it and press 'Generate!'. Then make sure to copy the generated section from the Notebook beginning with '++SCED import instructions++' to your ArkhamDB / arkham.build deck description.\nAfter doing so, the Deck Importer will be able to spawn these cards IF they are added to the mod's card index (for example by throwing them into the 'Additional Cards Box' next to the Player Cards Panel in the upper left corner of the table.\nIt also supports '- remove:' instructions to automatically remove placeholder cards.\nIf you are using a custom investigator, make sure to use a 'remove' instruction to remove the original one.",
     "color": "Grey",
     "id": 1,
-    "title": "FAQ: Use custom cards with ArkhamDB",
+    "title": "ArkhamDB and custom cards",
+    "visibleColor": {
+      "b": 0.5,
+      "g": 0.5,
+      "r": 0.5
+    }
+  },
+  "2": {
+    "body": "The 'auto-fail' token with the crown near the chaos bag tracks the chaos tokens that were drawn. It has the following features:\n\nLeft-click: Display the full list for all playermats\n\nMiddle-Click: Display your own stats\n\nRight-click: Reset the stats\n\nIts context menu offers the additional feature to 'Export Stats', which will send the data to a webservice like a google sheet. You can find a template sheet with setup instructions here:\n\nhttps://docs.google.com/spreadsheets/d/1AvTBEOF8fHQpEP1GJrrmPPZpZ50qRPu1Jt-m2ss8PWE/edit?usp=sharing",
+    "color": "Grey",
+    "id": 2,
+    "title": "Chaos Token Stats",
     "visibleColor": {
       "b": 0.5,
       "g": 0.5,

--- a/objects/ChaosBagStatTracker.766620.json
+++ b/objects/ChaosBagStatTracker.766620.json
@@ -16,7 +16,7 @@
     "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/14280472534262036296/D1D6263AF1FBA9EAD5AEB07499504108CC06E944/",
     "WidthScale": 0
   },
-  "Description": "Click to display the stats for drawn chaos tokens in the chat.\n\nLeft-click: Full list for all playermats\nMiddle-Click: Display your own stats\nRight-click: Reset the stats",
+  "Description": "Click to display the stats for drawn chaos tokens in the chat.\n\nLeft-click: Full list for all playermats\n\nMiddle-click: Display your own stats\n\nRight-click: Reset the stats\n\nChoose 'Export Stats' from the context menu to export the stats to a webservice like a google sheet.\n\nPlease refer to the notebook (top menu bar) for more details.",
   "GUID": "766620",
   "Hands": false,
   "HideWhenFaceDown": false,

--- a/objects/ChaosBagStatTracker.766620.json
+++ b/objects/ChaosBagStatTracker.766620.json
@@ -16,7 +16,7 @@
     "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/14280472534262036296/D1D6263AF1FBA9EAD5AEB07499504108CC06E944/",
     "WidthScale": 0
   },
-  "Description": "Click to display the stats for drawn chaos tokens in the chat.\n\nLeft-click: Full list for all playermats\n\nMiddle-click: Display your own stats\n\nRight-click: Reset the stats\n\nChoose 'Export Stats' from the context menu to export the stats to a webservice like a google sheet.\n\nPlease refer to the notebook (top menu bar) for more details.",
+  "Description": "Click to display the stats for drawn chaos tokens in the chat.\n\nLeft-click: Full list for all playermats\n\nMiddle-click: Display your own stats\n\nRight-click: Reset the stats\n\nPlease refer to the notebook (top menu bar) for more details.",
   "GUID": "766620",
   "Hands": false,
   "HideWhenFaceDown": false,

--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -1595,9 +1595,9 @@ function handleStatTrackerClick(player, clickType, _)
         -- print stats in order of the "ID_URL_MAP"
         for _, subtable in pairs(ID_URL_MAP) do
           local tokenName = subtable.name
-          local value = personalStats[tokenName]
-          if value and value ~= 0 then
-            printToAll(tokenName .. ': ' .. tostring(value))
+          local tokenCount = personalStats[tokenName]
+          if tokenCount and tokenCount ~= 0 then
+            printToAll(tokenName .. ': ' .. tostring(tokenCount))
           end
         end
 

--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -23,6 +23,7 @@ local TokenArrangerApi            = require("tokens/TokenArrangerApi")
 local TokenChecker                = require("tokens/TokenChecker")
 local TokenSpawnTrackerApi        = require("tokens/TokenSpawnTrackerApi")
 local VictoryDisplayApi           = require("mythos/VictoryDisplayApi")
+local WebRequestLib               = require("util/WebRequestLib")
 local XmlLib                      = require("util/XmlLib")
 local Zones                       = require("playermat/Zones")
 
@@ -46,7 +47,7 @@ local bagSearchers                = {}
 local lastZoneEnterObject         = nil
 
 -- online functionality related variables
-local failCount, library, requestObj, modMeta, searchFilter, authorFilter
+local failCount, library, requestObj, modMeta, searchFilter, authorFilter, googleAppsScriptUrl
 local downloadPending             = {}
 local acknowledgedUpgradeVersions = {}
 local authorList                  = {}
@@ -187,7 +188,8 @@ function onSave()
     chaosTokensGUID             = chaosTokensGUID,
     handVisibility              = handVisibility,
     optionPanel                 = optionPanel,
-    customTableSetupData        = TABLE_SETUP_DATA["Custom"]
+    customTableSetupData        = TABLE_SETUP_DATA["Custom"],
+    googleAppsScriptUrl         = googleAppsScriptUrl
   })
 end
 
@@ -1664,6 +1666,70 @@ function resetChaosTokenStatTracker(player)
       tokenDrawingStats = { ["Overall"] = {} }
     end
   )
+end
+
+function exportChaosTokenStats(player)
+  player.showInputDialog(
+    "Enter your Google Apps Script URL:",
+    googleAppsScriptUrl,
+    function(url)
+      if not url or url == "" then return end
+
+      if not string.startsWith(url, "https://script.google.com/") then
+        printToColor("Invalid Google Apps Script URL.", player.color, "Red")
+        return
+      end
+
+      googleAppsScriptUrl = url
+      sendChaosTokenStats(player, url)
+    end
+  )
+end
+
+function sendChaosTokenStats(player, url)
+  local targetMatColor = PlayermatApi.getMatColor(player.color)
+  local filteredStats = {}
+
+  -- filter for matching matColor or unseated mats
+  for matColor, stats in pairs(tokenDrawingStats) do
+    if matColor ~= "Overall" then
+      local relatedPlayerColor = PlayermatApi.getPlayerColor(matColor)
+      if matColor == targetMatColor or not Player[relatedPlayerColor].seated then
+        local invName = PlayermatApi.getInvestigatorName(matColor)
+        filteredStats[invName] = stats
+      end
+    end
+  end
+
+  local payload = {
+    apiVersion      = 1,
+    modVersion      = MOD_VERSION,
+    timestamp       = os.time(),
+    host            = getHostName(),
+    currentScenario = MythosAreaApi.returnTokenData().currentScenario,
+    stats           = filteredStats
+  }
+
+  WebRequestLib.post(
+    url,
+    JSON.encode(payload),
+    function()
+      printToColor("Chaos Token statistics exported successfully.", player.color, "Green")
+    end,
+    function(error)
+      printToColor("Failed to export Chaos Token statistics.", player.color, "Red")
+      printToColor(error, player.color, "Red")
+    end
+  )
+end
+
+function getHostName()
+  for _, player in ipairs(Player.getPlayers()) do
+    if player.host then
+      return player.steam_name
+    end
+  end
+  return "Unknown"
 end
 
 ---------------------------------------------------------

--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -249,7 +249,13 @@ function onLoad(savedData)
       }
     })
     statTracker.addContextMenuItem("Print my stats",
-      function(playerColor) handleStatTrackerClick(Player[playerColor], "-3") end)
+      function(playerColor)
+        handleStatTrackerClick(Player[playerColor], "-3")
+      end)
+    statTracker.addContextMenuItem("Export my stats",
+      function(playerColor)
+        exportChaosTokenStats(Player[playerColor])
+      end)
   end
 
   -- load specific option panel state for debugging / developing
@@ -1670,7 +1676,7 @@ end
 
 function exportChaosTokenStats(player)
   player.showInputDialog(
-    "Enter your Google Apps Script URL:",
+    "Enter Google Apps Script URL:",
     googleAppsScriptUrl,
     function(url)
       if not url or url == "" then return end
@@ -1695,30 +1701,50 @@ function sendChaosTokenStats(player, url)
     if matColor ~= "Overall" then
       local relatedPlayerColor = PlayermatApi.getPlayerColor(matColor)
       if matColor == targetMatColor or not Player[relatedPlayerColor].seated then
-        local invName = PlayermatApi.getInvestigatorName(matColor)
-        filteredStats[invName] = stats
+        local key = PlayermatApi.getInvestigatorName(matColor)
+        if key == "" then key = matColor end
+        if filteredStats[key] then
+          local i = 2
+          while filteredStats[key .. "_" .. i] do
+            i = i + 1
+          end
+          key = key .. "_" .. i
+        end
+        filteredStats[key] = stats
       end
     end
   end
 
   local payload = {
     apiVersion      = 1,
-    modVersion      = MOD_VERSION,
+    modVersion      = "v" .. MOD_VERSION,
     timestamp       = os.time(),
     host            = getHostName(),
     currentScenario = MythosAreaApi.returnTokenData().currentScenario,
     stats           = filteredStats
   }
 
-  WebRequestLib.post(
+  printToColor("Webrequest initiated.", player.color, "White")
+
+  WebRequestLib.postJson(
     url,
     JSON.encode(payload),
-    function()
-      printToColor("Chaos Token statistics exported successfully.", player.color, "Green")
+    function(response)
+      if response then
+        local decoded = JSON.decode(response)
+        if decoded.success then
+          printToColor("Export successful.", player.color, "Green")
+        else
+          printToColor("Export failed.", player.color, "Red")
+          printToColor("Details: " .. response, player.color, "Red")
+        end
+      else
+        printToColor("No response received.", player.color, "Yellow")
+      end
     end,
-    function(error)
+    function(error, responseCode)
       printToColor("Failed to export Chaos Token statistics.", player.color, "Red")
-      printToColor(error, player.color, "Red")
+      printToColor("HTTP " .. tostring(responseCode) .. ": " .. tostring(error), player.color, "Red")
     end
   )
 end

--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -252,7 +252,7 @@ function onLoad(savedData)
       function(playerColor)
         handleStatTrackerClick(Player[playerColor], "-3")
       end)
-    statTracker.addContextMenuItem("Export my stats",
+    statTracker.addContextMenuItem("Export stats",
       function(playerColor)
         exportChaosTokenStats(Player[playerColor])
       end)
@@ -1663,11 +1663,10 @@ function outputRandomMessage(playerColor, list, msgColor)
   printToAll(list[math.random(#list)]:gsub("<Name>", playerName):gsub("<Day>", os.date("%A")), msgColor)
 end
 
--- resets the count for each token to 0
 function resetChaosTokenStatTracker(player)
   player.showConfirmDialog("Are you sure you want to reset the Chaos Token stats?",
     function()
-      printToAll("Chaos Token stat tracker has been reset.")
+      printToAll("Chaos Token stats have been reset.")
       lastDrawnTokens = { ["Overall"] = {} }
       tokenDrawingStats = { ["Overall"] = {} }
     end
@@ -1693,31 +1692,27 @@ function exportChaosTokenStats(player)
 end
 
 function sendChaosTokenStats(player, url)
-  local targetMatColor = PlayermatApi.getMatColor(player.color)
   local filteredStats = {}
 
   -- filter for matching matColor or unseated mats
   for matColor, stats in pairs(tokenDrawingStats) do
     if matColor ~= "Overall" then
       local relatedPlayerColor = PlayermatApi.getPlayerColor(matColor)
-      if matColor == targetMatColor or not Player[relatedPlayerColor].seated then
-        local key = PlayermatApi.getInvestigatorName(matColor)
-        if key == "" then key = matColor end
-        if filteredStats[key] then
-          local i = 2
-          while filteredStats[key .. "_" .. i] do
-            i = i + 1
-          end
-          key = key .. "_" .. i
-        end
-        filteredStats[key] = stats
-      end
+      table.insert(filteredStats, {
+        investigator = PlayermatApi.getInvestigatorName(matColor),
+        player       = Player[relatedPlayerColor].seated
+            and Player[relatedPlayerColor].steam_name
+            or "",
+        exportedBy   = player.steam_name,
+        matColor     = matColor,
+        data         = stats
+      })
     end
   end
 
   local payload = {
     apiVersion      = 1,
-    modVersion      = "v" .. MOD_VERSION,
+    modVersion      = "'" .. MOD_VERSION,
     timestamp       = os.time(),
     host            = getHostName(),
     currentScenario = MythosAreaApi.returnTokenData().currentScenario,

--- a/src/util/WebRequestLib.ttslua
+++ b/src/util/WebRequestLib.ttslua
@@ -65,5 +65,28 @@ do
     end)
   end
 
+  -- Custom WebRequest to send JSON data.
+  ---@param uri table|string The URL for the request.
+  ---@param data table The JSON data to post.
+  ---@param onSuccess fun(content: string) Called when the request is successful.
+  ---@param onError fun(errorMessage: string, responseCode: number|nil) Called when an error occurs.
+  function WebRequestLib.postJson(uri, data, onSuccess, onError)
+    local headers = {
+      ["Content-Type"] = "application/json",
+      ["Accept"] = "application/json"
+    }
+
+    WebRequest.custom(
+      formatUri(uri),
+      "POST",
+      true,
+      data,
+      headers,
+      function(requestInstance)
+        handleResponse(requestInstance, onSuccess, onError)
+      end
+    )
+  end
+
   return WebRequestLib
 end


### PR DESCRIPTION
This adds a new "Export Stats" feature to the chaos token stat tracker.

For this to function, each player that wants to use it, needs to make a personal copy of the template sheet:
https://docs.google.com/spreadsheets/d/1AvTBEOF8fHQpEP1GJrrmPPZpZ50qRPu1Jt-m2ss8PWE/edit?usp=sharing