### PR TITLE
Add Aziza Steer (Reward)

### DIFF
--- a/objects/AllPlayerCards.15bb07.json
+++ b/objects/AllPlayerCards.15bb07.json
@@ -2156,6 +2156,7 @@
     "AzureFlame5.0ee874",
     "AzureFlame3.c5fb42",
     "AzureFlame.17319c",
+    "AzizaSteer.TtN_73059",
     "AwakenedMantle.e81861",
     "AutopsyReport3.60276",
     "AugustLindquist.83b588",

--- a/objects/AllPlayerCards.15bb07/AzizaSteer.TtN_73059.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AzizaSteer.TtN_73059.gmnotes
@@ -1,0 +1,10 @@
+{
+  "id": "73059",
+  "type": "Asset",
+  "slot": "Ally",
+  "class": "Neutral",
+  "cost": 3,
+  "level": 3,
+  "traits": "Ally. Detective.",
+  "cycle": "Traces to Nowhere"
+}

--- a/objects/AllPlayerCards.15bb07/AzizaSteer.TtN_73059.json
+++ b/objects/AllPlayerCards.15bb07/AzizaSteer.TtN_73059.json
@@ -1,0 +1,28 @@
+{
+  "CardID": 19200,
+  "CustomDeck": {
+    "192": {
+      "BackIsHidden": true,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/2342503777940352139/A2D42E7E5C43D045D72CE5CFC907E4F886C8C690/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15486110406040671089/113683C9392D8E7C374C827E58713BD8CD0A620A/",
+      "NumHeight": 1,
+      "NumWidth": 1,
+      "Type": 0
+    }
+  },
+  "Description": "Hardboiled",
+  "GMNotes_path": "AllPlayerCards.15bb07/AzizaSteer.TtN_73059.gmnotes",
+  "GUID": "TtN_73059",
+  "Name": "Card",
+  "Nickname": "Aziza Steer",
+  "Tags": [
+    "Asset",
+    "PlayerCard"
+  ],
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 1,
+    "scaleY": 1,
+    "scaleZ": 1
+  }
+}


### PR DESCRIPTION
Adds the Aziza Steer card from the upcoming standalone Traces to Nowhere