### PR TITLE
Ensure chaos tokens enter the bag face up

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -883,6 +883,7 @@ function returnChaosTokens()
     if token ~= nil then
       token.memo = nil
       token.destroyAttachments()
+      token.setRotation(chaosBag.getRotation())
       chaosBag.putObject(token)
     end
   end


### PR DESCRIPTION
This fixes an issue with the "cross" on ignored tokens persisting in the token splash when drawing the token again after it was returned.