### PR TITLE
Re-validate chaos token references

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -879,7 +879,7 @@ end
 -- returns all chaos tokens to the bag
 function returnChaosTokens()
   local chaosBag = findChaosBag()
-  for _, token in pairs(chaosTokens) do
+  for _, token in ipairs(chaosTokens) do
     if token ~= nil then
       token.memo = nil
       token.destroyAttachments()
@@ -1133,6 +1133,14 @@ function getReadableTokenName(tokenName)
   return tokenName
 end
 
+function removeInvalidChaosTokenReferences()
+  for i = #chaosTokens, 1, -1 do
+    if chaosTokens[i] == nil then
+      table.remove(chaosTokens, i)
+    end
+  end
+end
+
 -- called by playermats (by the "Draw chaos token" button)
 function drawChaosToken(params)
   if not canTouchChaosTokens() then return end
@@ -1142,6 +1150,9 @@ function drawChaosToken(params)
   end
 
   local matGUID = params.mat.getGUID()
+
+  -- double-check object references
+  removeInvalidChaosTokenReferences()
 
   -- return token(s) on other playermat first
   if chaosTokensLastMatGUID ~= nil and chaosTokensLastMatGUID ~= matGUID and #chaosTokens ~= 0 then


### PR DESCRIPTION
This fixes a bug that would cause you to need to click "draw chaos token" twice if there is no valid chaos token reference on the table (for example because you used Premonition, put the token on it and then discarded it).